### PR TITLE
Fix getChildrenAsUL compatibility error

### DIFF
--- a/code/Extensions/NewsHierarchy.php
+++ b/code/Extensions/NewsHierarchy.php
@@ -13,7 +13,7 @@ class NewsHierarchy extends Hierarchy
     public function getChildrenAsUL($attributes = "", $titleEval = '"<li>" . $child->Title', $extraArg = null,
                                     $limitToMarked = false, $childrenMethod = "AllChildrenIncludingDeleted",
                                     $numChildrenMethod = "numChildren", $rootCall = true,
-                                    $nodeCountThreshold = null, $nodeCountCallback = null)
+                                    $nodeCountThreshold = null, $nodeCountCallback = null, array $filteredIds = array())
     {
         if (get_class($this->owner) == 'NewsIndex') {
             $strURL = $this->owner->getNewsItemsEditLink();


### PR DESCRIPTION
Warning introduced in SilverStripe Framework 3.7.0.